### PR TITLE
feat: display all error properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .logs
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 script:
   - npm run ci
 after_script:
-  - npm i codecov && codecov
+  - npminstall codecov && codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm i npminstall && npminstall
+  - npm i npminstall && node_modules\.bin\npminstall
 
 test_script:
   - node --version

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -78,15 +78,15 @@ suite
 })
 .run({ async: false });
 
-// node version: v4.4.7, date: Fri Jul 08 2016 23:52:31 GMT+0800 (CST)
-//   Starting...
-//   8 tests completed.
+// node version: v4.4.7, date: Tue Jul 26 2016 00:27:29 GMT+0800 (CST)
+// Starting...
+// 8 tests completed.
 //
-//   logger.error(err)                     x  75,716 ops/sec ±6.78% (68 runs sampled)
-//   logger.info(message)                  x 146,234 ops/sec ±5.14% (76 runs sampled)
-//   logger.write(message)                 x 321,949 ops/sec ±8.95% (69 runs sampled)
-//   contextLogger.info(message)           x  96,073 ops/sec ±11.27% (64 runs sampled)
-//   logger.error(err) with JSON           x  32,696 ops/sec ±11.21% (70 runs sampled)
-//   logger.info(message) with JSON        x  53,863 ops/sec ±9.74% (64 runs sampled)
-//   logger.write(message) with JSON       x 196,964 ops/sec ±4.60% (80 runs sampled)
-//   contextLogger.info(message) with JSON x  55,410 ops/sec ±5.81% (78 runs sampled)
+// logger.error(err)                     x  29,936 ops/sec ±4.01% (75 runs sampled)
+// logger.info(message)                  x 163,694 ops/sec ±4.10% (76 runs sampled)
+// logger.write(message)                 x 390,052 ops/sec ±4.74% (76 runs sampled)
+// contextLogger.info(message)           x 136,986 ops/sec ±4.74% (78 runs sampled)
+// logger.error(err) with JSON           x  13,327 ops/sec ±2.43% (75 runs sampled)
+// logger.info(message) with JSON        x  61,547 ops/sec ±11.50% (70 runs sampled)
+// logger.write(message) with JSON       x 180,179 ops/sec ±8.81% (67 runs sampled)
+// contextLogger.info(message) with JSON x  54,134 ops/sec ±3.59% (76 runs sampled)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,15 +130,6 @@ module.exports = {
 };
 
 function formatError(err) {
-  err = {
-    name: err.name,
-    stack: err.stack,
-    message: err.message,
-    // nonstandard interfaces
-    code: err.code,
-    host: err.host,
-  };
-
   if (err.name === 'Error' && typeof err.code === 'string') {
     err.name = err.code + err.name;
   }
@@ -149,11 +140,25 @@ function formatError(err) {
   err.stack = err.stack || 'no_stack';
   // name and stack could not be change on node 0.11+
   const errStack = err.stack;
-  return util.format('nodejs.%s: %s\n%s\npid: %s\nhostname: %s\n',
+  const errProperties = Object.keys(err).map(key => inspect(key, err[key])).join('\n');
+  return util.format('nodejs.%s: %s\n%s\n%s\npid: %s\nhostname: %s\n',
     err.name,
     err.message,
     errStack.substring(errStack.indexOf('\n') + 1),
+    errProperties,
     process.pid,
     hostname
   );
+}
+
+function inspect(key, value) {
+  if (value && typeof value === 'object') {
+    // force in one line
+    value = util.inspect(value)
+      .replace(/^\s+/mg, '')
+      .replace(/\n/g, ' ');
+  } else {
+    value = util.inspect(value);
+  }
+  return key + ': ' + value;
 }


### PR DESCRIPTION
logger.error(err) 的性能大概是原来的 1/3 左右，err 对象的属性越多越慢，但是感觉还是值得的。

```bash
nodejs.MySomeError: foo (eggjs.org)
    at Context.<anonymous> (/Users/deadhorse/git/egg-opensource/egg-logger/test/lib/formatter.test.js:79:17)
    at next (native)
    at run (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:265:37)
    at Context.<anonymous> (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:261:14)
    at apply (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:363:38)
    at tryRun (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:241:19)
    at runThunk (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:234:11)
    at continuation (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:179:54)
    at child (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:171:24)
    at /Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunks/4.3.0/thunks/thunks.js:161:14
    at Context._fn (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/thunk-mocha/1.0.3/thunk-mocha/index.js:27:59)
    at callFnAsync (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runnable.js:349:8)
    at Test.Runnable.run (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runnable.js:301:7)
    at Runner.runTest (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runner.js:422:10)
    at /Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runner.js:528:12
    at next (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runner.js:342:14)
    at /Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runner.js:352:7
    at next (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runner.js:284:14)
    at Immediate._onImmediate (/Users/deadhorse/git/egg-opensource/egg-logger/node_modules/.npminstall/mocha/2.5.3/mocha/lib/runner.js:320:5)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
code: 'MySome'
host: 'eggjs.org'
addition: { userId: 12345, message: 'mock error' }
errors: [ { code: 'missing_field', field: 'name', message: 'required' }, { code: 'invalid', field: 'age', message: 'should be an integer' } ]
name: 'MySomeError'
pid: 59653
hostname: dead-horsedeMacBook-Pro.local
```