### PR TITLE
use Infinity to improve semantics and performance

### DIFF
--- a/lib/level.js
+++ b/lib/level.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.ALL = -100000;
+exports.ALL = -Infinity;
 
 /**
  * Debug log for execute tracing
@@ -31,4 +31,4 @@ exports.WARN = 2;
  */
 exports.ERROR = 3;
 
-exports.NONE = 100000;
+exports.NONE = Infinity;


### PR DESCRIPTION
While using `Infinity` and `-Infinity` instead of `100000` and `-100000`, we will gain improvement of semantics and performance (especially on comparing number with `Infinity`).

bench: 

script: https://gist.github.com/DavidCai1993/fb3ccc04d0c27261aef2eff3892d86a4

output: 

```
     809,360,009 op/s » Infinity > 100
     143,389,949 op/s » NONE > 100
     144,250,523 op/s » -Infinity < 100
     136,641,309 op/s » ALL < 100


  Suites:  1
  Benches: 4
  Elapsed: 3,130.49 ms
```