### PR TITLE
feat: add .unredirect() for logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 .logs
 tmp
+*.log

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -94,6 +94,15 @@ class Logger extends Map {
   }
 
   /**
+   * Un-redirect specify level log
+   * @param {String} level - log level
+   */
+  unredirect(level) {
+    level = level.toUpperCase();
+    this.redirectLoggers.delete(level);
+  }
+
+  /**
    * Reload all transports
    */
   reload() {

--- a/test/lib/egg/error_logger.test.js
+++ b/test/lib/egg/error_logger.test.js
@@ -33,7 +33,7 @@ describe('test/egg/error_logger.test.js', () => {
     });
   });
 
-  it('should lgo error level only', done => {
+  it('should log error level only', done => {
     const options = {
       file: filepath,
       flushInterval: 10,

--- a/test/lib/egg/logger.test.js
+++ b/test/lib/egg/logger.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const coffee = require('coffee');
 const rimraf = require('rimraf');
 const levels = require('../../../index');
+const Logger = require('../../../index').EggLogger;
 
 describe('test/egg/logger.test.js', () => {
   const loggerFile = path.join(__dirname, '../../fixtures/egg_logger.js');
@@ -29,6 +30,35 @@ describe('test/egg/logger.test.js', () => {
         .should.match(/"message":"error foo"/);
       done();
     });
+  });
+
+  it('should not redirect to any logger', done => {
+    const file1 = path.join(__dirname, '../../fixtures/tmp/file1.log');
+    const file2 = path.join(__dirname, '../../fixtures/tmp/file2.log');
+    const logger1 = new Logger({
+      file: file1,
+      buffer: false,
+    });
+    const logger2 = new Logger({
+      file: file2,
+      buffer: false,
+    });
+
+    logger1.redirect('warn', logger2);
+    logger1.redirect('error', logger2);
+    logger1.unredirect('error');
+    logger1.warn('foo');
+    logger1.error('bar');
+
+    setTimeout(() => {
+      const content1 = fs.readFileSync(file1, 'utf8');
+      const content2 = fs.readFileSync(file2, 'utf8');
+      content1.should.not.match(/foo/);
+      content1.should.match(/bar/);
+      content2.should.match(/foo/);
+      content2.should.not.match(/bar/);
+      done();
+    }, 100);
   });
 
   describe('level', () => {


### PR DESCRIPTION
有时候不想把error都redirect到common-error里，特别是记录任务型的日志（一个任务分多个step），这样记在一个文件里比较好查看