### PR TITLE
Fix implicit-any error for EggLoggers#set

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,7 +120,7 @@ export interface EggLoggersOptions {
   eol?: string;
 }
 
-export class EggLoggers extends Map {
+export class EggLoggers extends Map<string, Logger> {
   constructor(options: EggLoggersOptions);
 
   /**
@@ -138,7 +138,7 @@ export class EggLoggers extends Map {
    * @param {String} name - logger name
    * @param {Logger} logger - Logger instance
    */
-  set(name: string, logger: Logger);
+  set(name: string, logger: Logger): this;
 
   [key: string]: any;
 }


### PR DESCRIPTION
Previously this had a compile error under TypeScript's `--noImpicitAny` option due to `set` lacking a return type. (Having a `set` signature is actually redundant given that this extends from `Map`.)