### PR TITLE
fix: formatter invalid when options.json is true

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,9 +100,9 @@ module.exports = {
       if (options.json === true) {
         output = formatter
           ? JSON.stringify(formatter(meta))
-          : JSON.stringify(meta)
+          : JSON.stringify(meta);
       } else {
-        output = formatter(meta)
+        output = formatter(meta);
       }
     } else {
       output = message;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,7 +96,14 @@ module.exports = {
       meta.pid = process.pid;
       meta.hostname = hostname;
       meta.message = message;
-      output = options.json === true ? JSON.stringify(meta) : formatter(meta);
+
+      if (options.json === true) {
+        output = formatter
+          ? JSON.stringify(formatter(meta))
+          : JSON.stringify(meta)
+      } else {
+        output = formatter(meta)
+      }
     } else {
       output = message;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

no.


##### Description of change
![image](https://user-images.githubusercontent.com/3380894/53101260-5d4f7180-3564-11e9-93c0-98765bdf61ed.png)
原来的书写方式导致当 `options.json` 为 `true` 的时候，formatter 不会被调用，也就是说，json 输出无法被自定义。

