### PR TITLE
fix: crash when format a getter-only error stack

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -141,15 +141,8 @@ function formatError(err) {
     err.message += ` (${err.host})`;
   }
 
-  if (!err.stack) {
-    const property = Object.getOwnPropertyDescriptor(err, 'stack');
-    if (property.value !== undefined || (property.get && property.set)) {
-      err.stack = 'no_stack';
-    }
-  }
-
   // name and stack could not be change on node 0.11+
-  const errStack = err.stack;
+  const errStack = err.stack || 'no_stack';
   const errProperties = Object.keys(err).map(key => inspect(key, err[key])).join('\n');
   return util.format('nodejs.%s: %s\n%s\n%s\npid: %s\nhostname: %s\n',
     err.name,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -140,7 +140,14 @@ function formatError(err) {
   if (err.host) {
     err.message += ` (${err.host})`;
   }
-  err.stack = err.stack || 'no_stack';
+
+  if (!err.stack) {
+    const property = Object.getOwnPropertyDescriptor(err, 'stack');
+    if (property.value !== undefined || (property.get && property.set)) {
+      err.stack = 'no_stack';
+    }
+  }
+
   // name and stack could not be change on node 0.11+
   const errStack = err.stack;
   const errProperties = Object.keys(err).map(key => inspect(key, err[key])).join('\n');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

logger

##### Description of change
<!-- Provide a description of the change below this comment. -->

目前遇到的 Nunjucks 抛出的错误就是魔改过后的 `stack` 是一个 `getter` 但是没有对应的 `setter`：

```js
> Object.getOwnPropertyDescriptor(err, 'stack');

{ get: [Function: get],
  set: undefined,
  enumerable: false,
  configurable: true }
```