### PR TITLE
refactor: context formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tmp
 *.log
 .nyc_output
 .idea
+package-lock.json
+.vscode

--- a/lib/egg/context_logger.js
+++ b/lib/egg/context_logger.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const utils = require('../utils');
+
 /**
  * Request context Logger, itself isn't a {@link Logger}.
  */
@@ -42,7 +44,7 @@ class ContextLogger {
   const LEVEL = level.toUpperCase();
   ContextLogger.prototype[level] = function() {
     const meta = {
-      formatter: contextFormatter,
+      formatter: utils.contextFormatter,
       paddingMessage: this.paddingMessage,
     };
     Object.defineProperty(meta, 'ctx', {
@@ -54,7 +56,3 @@ class ContextLogger {
 });
 
 module.exports = ContextLogger;
-
-function contextFormatter(meta) {
-  return meta.date + ' ' + meta.level + ' ' + meta.pid + ' ' + meta.paddingMessage + ' ' + meta.message;
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,21 +37,12 @@ module.exports = {
 
   // output to Terminal format
   consoleFormatter(meta) {
-    let msg = meta.date + ' ' + meta.level + ' ' + meta.pid + ' ' + meta.message;
-    if (!chalk.supportsColor) {
-      return msg;
-    }
+    const msg = meta.date + ' ' + meta.level + ' ' + meta.pid + ' ' + meta.message;
+    return chalkMSG(meta.level, msg);
+  },
 
-    if (meta.level === 'ERROR') {
-      return chalk.red(msg);
-    } else if (meta.level === 'WARN') {
-      return chalk.yellow(msg);
-    }
-
-    msg = msg.replace(duartionRegexp, chalk.green('$1'));
-    msg = msg.replace(categoryRegexp, chalk.blue('$1'));
-    msg = msg.replace(httpMethodRegexp, chalk.cyan('$1 '));
-    return msg;
+  contextFormatter(meta) {
+    return meta.date + ' ' + meta.level + ' ' + meta.pid + ' ' + meta.paddingMessage + ' ' + meta.message;
   },
 
   /**
@@ -190,4 +181,26 @@ function formatObject(obj) {
     /* istanbul ignore next */
     return String(obj);
   }
+}
+
+/**
+ *  chalk the message
+ * @param {*} level - log level
+ * @param {*} msg - the content of message
+ */
+function chalkMSG(level, msg) {
+  if (!chalk.supportsColor) {
+    return msg;
+  }
+
+  if (level === 'ERROR') {
+    return chalk.red(msg);
+  } else if (level === 'WARN') {
+    return chalk.yellow(msg);
+  }
+
+  msg = msg.replace(duartionRegexp, chalk.green('$1'));
+  msg = msg.replace(categoryRegexp, chalk.blue('$1'));
+  msg = msg.replace(httpMethodRegexp, chalk.cyan('$1 '));
+  return msg;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

我本来是想让contextFormatter输出在控制台的内容也可以显示颜色的，发现要改部分原有测试用例，就放弃了。现在只是整理了一下这部分的代码 