### PR TITLE
fix: stream reload testcase.  Bty, the rean  is when log method invok…

### DIFF
--- a/test/lib/transports/file.test.js
+++ b/test/lib/transports/file.test.js
@@ -262,13 +262,8 @@ describe('test/transports/file.test.js', () => {
       assert(message.match(reg));
     });
     logger.info('info foo');
-    yield sleep(1);
-    logger.info('info foo');
-    yield sleep(1);
-    logger.info('info foo');
-    yield sleep(1);
+    yield sleep(100);
     mm.restore();
-
     yield sleep(1);
     // should be flush again
     logger.info('info foo');
@@ -277,7 +272,7 @@ describe('test/transports/file.test.js', () => {
     yield sleep(1000);
     const content = fs.readFileSync(logfile, 'utf8');
     assert(content === 'info foo\ninfo foo\ninfo foo\n');
-    assert(errorCount === 3);
+    assert(errorCount === 1);
   });
 
 });


### PR DESCRIPTION
…e second time, stream has been closed, log method throw error -  'log stream had been closed'.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [Y] `npm test` passes
- [Y] tests and/or benchmarks are included
- [Y] documentation is changed or added
- [Y] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
no affect

##### Description of change
<!-- Provide a description of the change below this comment. -->
fix: stream reload testcase. Bty, the rean is when log method invoke second time, stream has been closed, log method throw error - 'log stream had been closed'.