### PR TITLE
feat: Only output logs in JSON file format is supported

### DIFF
--- a/lib/egg/logger.js
+++ b/lib/egg/logger.js
@@ -22,6 +22,7 @@ class EggLogger extends Logger {
    *  - {Function} [formatter] - log format function
    *  - {String} [jsonFile] - JSON log file
    *  - {Boolean} [outputJSON = false] - send JSON log or not
+   *  - {Boolean} [outputJSONOnly = false] - only send JSON log
    *  - {Boolean} [buffer] - use {@link FileBufferTransport} or not
    *  - {String} [eol] - end of line char
    *  - {String} [concentrateError] - whether write error logger to common-error.log, `duplicate` / `redirect` / `ignore`
@@ -37,16 +38,18 @@ class EggLogger extends Logger {
 
     const EggFileTransport = this.options.buffer === true ? FileBufferTransport : FileTransport;
 
-    const fileTransport = new EggFileTransport({
-      file: this.options.file,
-      level: this.options.level || 'INFO',
-      encoding: this.options.encoding,
-      formatter: this.options.formatter,
-      contextFormatter: this.options.contextFormatter,
-      flushInterval: this.options.flushInterval,
-      eol: this.options.eol,
-    });
-    this.set('file', fileTransport);
+    if (!this.options.outputJSONOnly) {
+      const fileTransport = new EggFileTransport({
+        file: this.options.file,
+        level: this.options.level || 'INFO',
+        encoding: this.options.encoding,
+        formatter: this.options.formatter,
+        contextFormatter: this.options.contextFormatter,
+        flushInterval: this.options.flushInterval,
+        eol: this.options.eol,
+      });
+      this.set('file', fileTransport);
+    }
 
     if (this.options.jsonFile) {
       const jsonFileTransport = new EggFileTransport({
@@ -101,6 +104,7 @@ class EggLogger extends Logger {
       formatter: utils.defaultFormatter,
       buffer: true,
       outputJSON: false,
+      outputJSONOnly: false,
       jsonFile: '',
     };
   }

--- a/lib/egg/loggers.js
+++ b/lib/egg/loggers.js
@@ -16,6 +16,7 @@ const defaults = {
   level: 'INFO',
   consoleLevel: 'NONE',
   outputJSON: false,
+  outputJSONOnly: false,
   buffer: true,
   appLogName: '',
   coreLogName: '',
@@ -41,6 +42,7 @@ class Loggers extends Map {
    *   - {String} [level = INFO] - file log level
    *   - {String} [consoleLevel = NONE] - console log level
    *   - {Boolean} [outputJSON = false] - send JSON log or not
+   *   - {Boolean} [outputJSONOnly = false] - send JSON log or not
    *   - {Boolean} [buffer = true] - use {@link FileBufferTransport} or not
    *   - {String} appLogName - egg app file logger name
    *   - {String} coreLogName - egg core file logger name


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
At present, egg will output log files in non JSON format by default. I hope to add the outputJsonOnly attribute to support only outputting log files in JSON format, because the elk log collection system sometimes has collection problems due to files in non JSON format.

