### PR TITLE
feat: support custom concentrateLoggerName options

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,7 +35,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install Dependencies
-      run: npm i -g npminstall && npminstall
+      run: npm i -g npminstall@5 && npminstall
 
     - name: Continuous Integration
       run: npm run ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [8, 10, 12, 14, 16]
+        node-version: [8, 10, 12, 14, 16, 18]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/lib/egg/loggers.js
+++ b/lib/egg/loggers.js
@@ -23,7 +23,7 @@ const defaults = {
   agentLogName: '',
   errorLogName: '',
   concentrateError: 'duplicate',
-  concentrateLoggerName: 'errorLogger',
+  concentrateErrorLoggerName: 'errorLogger',
 };
 
 /**
@@ -50,8 +50,8 @@ class Loggers extends Map {
    *   - {String} agentLogName - egg agent file logger name
    *   - {String} errorLogName - err common error logger name
    *   - {String} eol - end of line char
-   *   - {String} [concentrateError = duplicate] - whether write error logger to `concentrateLoggerName` logger, `duplicate` / `redirect` / `ignore`
-   *   - {String} [concentrateLoggerName = errorLogger] - concentrate logger name
+   *   - {String} [concentrateError = duplicate] - whether write error logger to `concentrateErrorLoggerName` logger, `duplicate` / `redirect` / `ignore`
+   *   - {String} [concentrateErrorLoggerName = errorLogger] - concentrate logger name
    * - customLogger
    */
   constructor(config) {
@@ -140,7 +140,7 @@ class Loggers extends Map {
   setConcentrateError(name, logger) {
     // redirect ERROR log to errorLogger, except errorLogger itself
     if (name !== 'errorLogger') {
-      const concentrateLogger = this.get(logger.options.concentrateLoggerName);
+      const concentrateLogger = this.get(logger.options.concentrateErrorLoggerName);
       if (!concentrateLogger) return;
 
       switch (logger.options.concentrateError) {

--- a/lib/egg/loggers.js
+++ b/lib/egg/loggers.js
@@ -79,23 +79,21 @@ class Loggers extends Map {
       logger = new Logger(utils.assign({}, loggerConfig, {
         file: loggerConfig.agentLogName,
       }));
-      this.set('logger', logger);
 
       coreLogger = new Logger(utils.assign({}, loggerConfig, loggerConfig.coreLogger, {
         file: loggerConfig.agentLogName,
       }));
-      this.set('coreLogger', coreLogger);
     } else {
       logger = new Logger(utils.assign({}, loggerConfig, {
         file: loggerConfig.appLogName,
       }));
-      this.set('logger', logger);
-
+      
       coreLogger = new Logger(utils.assign({}, loggerConfig, loggerConfig.coreLogger, {
         file: loggerConfig.coreLogName,
       }));
-      this.set('coreLogger', coreLogger);
     }
+    this.set('logger', logger);
+    this.set('coreLogger', coreLogger);
 
     for (const name in customLoggerConfig) {
       const logger = new CustomLogger(utils.assign({}, loggerConfig, customLoggerConfig[name]));

--- a/lib/egg/loggers.js
+++ b/lib/egg/loggers.js
@@ -87,7 +87,7 @@ class Loggers extends Map {
       logger = new Logger(utils.assign({}, loggerConfig, {
         file: loggerConfig.appLogName,
       }));
-      
+
       coreLogger = new Logger(utils.assign({}, loggerConfig, loggerConfig.coreLogger, {
         file: loggerConfig.coreLogName,
       }));
@@ -132,7 +132,7 @@ class Loggers extends Map {
     if (this.has(name)) {
       return;
     }
-    
+
     this[name] = logger;
     super.set(name, logger);
   }

--- a/lib/egg/loggers.js
+++ b/lib/egg/loggers.js
@@ -23,6 +23,7 @@ const defaults = {
   agentLogName: '',
   errorLogName: '',
   concentrateError: 'duplicate',
+  concentrateLoggerName: 'errorLogger',
 };
 
 /**
@@ -49,7 +50,8 @@ class Loggers extends Map {
    *   - {String} agentLogName - egg agent file logger name
    *   - {String} errorLogName - err common error logger name
    *   - {String} eol - end of line char
-   *   - {String} [concentrateError = duplicate] - whether write error logger to common-error.log, `duplicate` / `redirect` / `ignore`
+   *   - {String} [concentrateError = duplicate] - whether write error logger to `concentrateLoggerName` logger, `duplicate` / `redirect` / `ignore`
+   *   - {String} [concentrateLoggerName = errorLogger] - concentrate logger name
    * - customLogger
    */
   constructor(config) {
@@ -71,23 +73,25 @@ class Loggers extends Map {
     }));
     this.set('errorLogger', errorLogger);
 
+    let coreLogger;
+    let logger;
     if (loggerConfig.type === 'agent') {
-      const logger = new Logger(utils.assign({}, loggerConfig, {
+      logger = new Logger(utils.assign({}, loggerConfig, {
         file: loggerConfig.agentLogName,
       }));
       this.set('logger', logger);
 
-      const coreLogger = new Logger(utils.assign({}, loggerConfig, loggerConfig.coreLogger, {
+      coreLogger = new Logger(utils.assign({}, loggerConfig, loggerConfig.coreLogger, {
         file: loggerConfig.agentLogName,
       }));
       this.set('coreLogger', coreLogger);
     } else {
-      const logger = new Logger(utils.assign({}, loggerConfig, {
+      logger = new Logger(utils.assign({}, loggerConfig, {
         file: loggerConfig.appLogName,
       }));
       this.set('logger', logger);
 
-      const coreLogger = new Logger(utils.assign({}, loggerConfig, loggerConfig.coreLogger, {
+      coreLogger = new Logger(utils.assign({}, loggerConfig, loggerConfig.coreLogger, {
         file: loggerConfig.coreLogName,
       }));
       this.set('coreLogger', coreLogger);
@@ -96,6 +100,13 @@ class Loggers extends Map {
     for (const name in customLoggerConfig) {
       const logger = new CustomLogger(utils.assign({}, loggerConfig, customLoggerConfig[name]));
       this.set(name, logger);
+    }
+
+    // setConcentrateError at the end
+    this.setConcentrateError('logger', logger);
+    this.setConcentrateError('coreLogger', coreLogger);
+    for (const name in customLoggerConfig) {
+      this.setConcentrateError(name, this.get(name));
     }
   }
 
@@ -123,15 +134,23 @@ class Loggers extends Map {
     if (this.has(name)) {
       return;
     }
+    
+    this[name] = logger;
+    super.set(name, logger);
+  }
 
+  setConcentrateError(name, logger) {
     // redirect ERROR log to errorLogger, except errorLogger itself
     if (name !== 'errorLogger') {
+      const concentrateLogger = this.get(logger.options.concentrateLoggerName);
+      if (!concentrateLogger) return;
+
       switch (logger.options.concentrateError) {
         case 'duplicate':
-          logger.duplicate('error', this.errorLogger, { excludes: [ 'console' ] });
+          logger.duplicate('error', concentrateLogger, { excludes: [ 'console' ] });
           break;
         case 'redirect':
-          logger.redirect('error', this.errorLogger);
+          logger.redirect('error', concentrateLogger);
           break;
         case 'ignore':
           break;
@@ -139,8 +158,6 @@ class Loggers extends Map {
           break;
       }
     }
-    this[name] = logger;
-    super.set(name, logger);
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "index.d.ts"
   ],
   "ci": {
-    "version": "8, 10, 12, 14, 16",
+    "version": "8, 10, 12, 14, 16, 18",
     "type": "github",
     "os": {
       "github": "linux, macos"

--- a/test/lib/egg/loggers.test.js
+++ b/test/lib/egg/loggers.test.js
@@ -16,6 +16,8 @@ describe('test/egg/loggers.test.js', () => {
   const dLog = path.join(tmp, 'd.log');
   const eLog = path.join(tmp, 'e.log');
   const fLog = 'f.log';
+  const gLog = path.join(tmp, 'g.log');
+  const hLog = path.join(tmp, 'h.log');
 
   before(() => rimraf(tmp));
   after(() => rimraf(tmp));
@@ -58,6 +60,14 @@ describe('test/egg/loggers.test.js', () => {
           },
           fLogger: {
             file: fLog,
+          },
+          gLogger: {
+            file: gLog,
+            concentrateLoggerName: 'hLogger',
+          },
+          hLogger: {
+            file: hLog,
+            concentrateError: 'ignore',
           },
         },
       });
@@ -112,6 +122,18 @@ describe('test/egg/loggers.test.js', () => {
       assert(loggers.cLogger.options.concentrateError === 'duplicate');
       assert(loggers.dLogger.options.concentrateError === 'redirect');
       assert(loggers.eLogger.options.concentrateError === 'ignore');
+    });
+
+    it('gLogger error will duplicate to hLogger', function* () {
+      loggers.gLogger.error('this is gLogger error foo1');
+
+      yield sleep(10);
+
+      assert(fs.readFileSync(hLog, 'utf8').includes('this is gLogger error foo1'));
+      assert(fs.readFileSync(gLog, 'utf8').includes('this is gLogger error foo1'));
+
+      // should not duplicate to common-error.log
+      assert(!fs.readFileSync(path.join(tmp, 'common-error.log'), 'utf8').includes('this is gLogger error foo1'));
     });
 
     it('should app.logger log to appLogName', function*() {

--- a/test/lib/egg/loggers.test.js
+++ b/test/lib/egg/loggers.test.js
@@ -63,7 +63,7 @@ describe('test/egg/loggers.test.js', () => {
           },
           gLogger: {
             file: gLog,
-            concentrateLoggerName: 'hLogger',
+            concentrateErrorLoggerName: 'hLogger',
           },
           hLogger: {
             file: hLog,


### PR DESCRIPTION
separate biz error log and framework error log, config like this

```
// config.js

module.exports = (appInfo) => ({
  customLogger: {
    middlewareLogger: {
      file: path.join(appInfo.root, 'logs/middleware.log'),
      concentrateErrorLoggerName: 'runtimeErrorLogger'
    },
    runtimeErrorLogger: {
      file: path.join(appInfo.root, 'logs/runtime-error.log'),
      concentrateError: 'ignore',
    },
  }
})
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

