### PR TITLE
fix: ctx logger paddingMessage should be a getter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,8 @@ export class EggCustomLogger extends Logger {}
 
 export class EggContextLogger {
   constructor(ctx: any, logger: Logger);
-  readonly paddingMessage: string;
+  ctx: any;
+  get paddingMessage(): string;
   write(msg: string): void;
   error(msg: any, ...args: any[]): void;
   warn(msg: any, ...args: any[]): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,19 @@ interface ILoggerLevel {
 export const levels: ILoggerLevel;
 export type LoggerLevel = keyof ILoggerLevel;
 
+export type LoggerMeta = {
+  level: LoggerLevel;
+  date: string;
+  pid: number;
+  hostname: string;
+  message: string;
+  paddingMessage?: string;
+  ctx?: any;
+  raw: boolean;
+  formatter?: Function;
+  [key: string]: any;
+};
+
 export interface LoggerOptions {
   level?: LoggerLevel;
   encoding?: string;
@@ -21,8 +34,8 @@ export interface LoggerOptions {
 
 export interface EggLoggerOptions extends LoggerOptions {
   file: string;
-  formatter?: (meta?: object) => string;
-  contextFormatter?: (meta?: object) => string;
+  formatter?: (meta?: LoggerMeta) => string;
+  contextFormatter?: (meta?: LoggerMeta) => string;
   paddingMessageFormatter?: (ctx: object) => string;
   jsonFile?: string;
   outputJSON?: boolean;
@@ -54,9 +67,9 @@ export class Logger<T extends LoggerOptions = EggLoggerOptions> extends Map<stri
    * It's proxy to {@link Transport}'s log method.'
    * @param {String} level - log level
    * @param {Array} args - log arguments
-   * @param {Object} meta - log meta
+   * @param {LoggerMeta} [meta] - log meta
    */
-  log(level: LoggerLevel, args: any[], meta: object): void;
+  log(level: LoggerLevel, args: any[], meta?: LoggerMeta): void;
 
   /**
    * write raw log to all transports
@@ -176,8 +189,8 @@ export class EggLoggers extends Map<string, Logger> {
 
 export interface TransportOptions {
   level?: LoggerLevel;
-  formatter?: (meta?: object) => string;
-  contextFormatter?: (meta?: object) => string;
+  formatter?: (meta?: LoggerMeta) => string;
+  contextFormatter?: (meta?: LoggerMeta) => string;
   paddingMessageFormatter?: (ctx: object) => string;
   json?: boolean;
   encoding?: string;
@@ -203,7 +216,7 @@ export class Transport<T extends TransportOptions = TransportOptions> {
   level: LoggerLevel;
   enable(): void;
   shouldLog(level: LoggerLevel): boolean;
-  log(level: LoggerLevel, args: any[], meta: object): void;
+  log(level: LoggerLevel, args: any[], meta?: LoggerMeta): void;
   reload(): void;
   close(): void;
   end(): void;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 import { AsyncLocalStorage } from 'async_hooks';
-import { EggLoggerOptions, Logger } from '.';
+import { EggLoggerOptions, Logger, EggContextLogger } from '.';
 
 const options = {
   formatter(meta) {
@@ -17,3 +17,17 @@ expectType<string>(options.paddingMessageFormatter!({}));
 const logger = {} as Logger;
 expectType<'duplicate' | 'redirect' | 'ignore'>(logger.options.concentrateError!);
 expectType<AsyncLocalStorage<any>>(logger.options.localStorage!);
+
+const ctxLogger = {} as EggContextLogger;
+expectType<string>(ctxLogger.paddingMessage);
+expectType<object>(ctxLogger.ctx);
+
+class CustomEggContextLogger extends EggContextLogger {
+  get paddingMessage() {
+    return 'hello, ' + this.ctx.url;
+  }
+}
+
+const customCtxLogger = {} as CustomEggContextLogger;
+expectType<string>(customCtxLogger.paddingMessage);
+expectType<object>(customCtxLogger.ctx);


### PR DESCRIPTION
add missing ctx define on EggContextLogger and LoggerMeta

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
