### PR TITLE
fix: Transport log should return string type

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,3 +14,5 @@ jobs:
     with:
       os: 'ubuntu-latest, macos-latest'
       version: '14.18.0, 14, 16, 18, 20, 22'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Test coverage][codecov-image]][codecov-url]
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![npm download][download-image]][download-url]
+[![Node.js Version](https://img.shields.io/node/v/egg-logger.svg?style=flat)](https://nodejs.org/en/download/)
 
 [npm-image]: https://img.shields.io/npm/v/egg-logger.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/egg-logger

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,7 +221,7 @@ export class Transport<T extends TransportOptions = TransportOptions> {
   level: LoggerLevel;
   enable(): void;
   shouldLog(level: LoggerLevel): boolean;
-  log(level: LoggerLevel, args: any[], meta?: LoggerMeta): void;
+  log(level: LoggerLevel, args: any[], meta?: LoggerMeta): string;
   reload(): void;
   close(): void;
   end(): void;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,9 @@
 import { expectType } from 'tsd';
 import { AsyncLocalStorage } from 'async_hooks';
-import { EggLoggerOptions, Logger, EggContextLogger, EggConsoleLogger } from '.';
+import {
+  EggLoggerOptions, Logger, EggContextLogger, EggConsoleLogger,
+  Transport, LoggerLevel,
+} from '.';
 
 const options = {
   formatter(meta: any) {
@@ -36,3 +39,8 @@ const consoleLogger = new EggConsoleLogger();
 expectType<number>(consoleLogger.size);
 expectType<number>(new EggConsoleLogger({}).size);
 expectType<number>(new EggConsoleLogger({ encoding: 'utf8' }).size);
+
+const transport = {} as Transport;
+expectType<Transport>(transport);
+expectType<string>(transport.level);
+expectType<string>(transport.log('ALL', []));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a badge for Node.js version compatibility to the README.md.
  
- **Bug Fixes**
	- Updated the `log` method in the `Transport` class to return a string, enhancing its functionality.

- **Chores**
	- Modified GitHub Actions workflow to include `CODECOV_TOKEN` for improved code coverage reporting. 
	- Expanded type definitions in the test file by adding new imports for `Transport` and `LoggerLevel`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->